### PR TITLE
MZNE-1043 パスワード入力欄の「表示」ボタンを、入力カーソルがパスワードフィールドにある状態でも押せるようにする

### DIFF
--- a/Sources/UI/Base/Form/Component/FormTextField.swift
+++ b/Sources/UI/Base/Form/Component/FormTextField.swift
@@ -73,21 +73,16 @@ public final class FormTextField: UITextField, UITextFieldDelegate {
     }
 
     override public func rightViewRect(forBounds bounds: CGRect) -> CGRect {
-        if !self.showOptionButton {
-            return CGRect(
-                x: self.frame.width - self.inset,
-                y: 0,
-                width: self.inset,
-                height: bounds.height
-            )
-        } else {
-            return CGRect(
-                x: self.frame.width - self.optionButtonWidth,
-                y: 0,
-                width: self.optionButtonWidth,
-                height: bounds.height
-            )
-        }
+        .init(
+            x: self.showOptionButton
+                ? self.frame.width - self.optionButtonWidth
+                : self.frame.width - self.inset,
+            y: 0,
+            width: self.showOptionButton
+                ? self.optionButtonWidth
+                : self.inset,
+            height: bounds.height
+        )
     }
 
     public func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {

--- a/Sources/UI/Base/Form/Component/FormTextField.swift
+++ b/Sources/UI/Base/Form/Component/FormTextField.swift
@@ -49,15 +49,15 @@ public final class FormTextField: UITextField, UITextFieldDelegate {
 
     private func calcRect(forBounds bounds: CGRect) -> CGRect {
         var rect = bounds.insetBy(dx: self.inset, dy: self.inset)
-        if !self.showOptionButton {
-            return rect
-        } else {
+
+        if self.showOptionButton {
             rect.size = CGSize(
                 width: rect.width - (self.optionButtonWidth - self.inset),
                 height: rect.height
             )
-            return rect
         }
+
+        return rect
     }
 
     override public func textRect(forBounds bounds: CGRect) -> CGRect {

--- a/Sources/UI/Base/Form/Component/FormTextField.swift
+++ b/Sources/UI/Base/Form/Component/FormTextField.swift
@@ -50,6 +50,30 @@ public final class FormTextField: UITextField, UITextFieldDelegate {
         return CGRect(x: 0, y: 0, width: self.inset, height: self.textFieldHeight)
     }
 
+    private func calcRect(forBounds bounds: CGRect) -> CGRect {
+        var rect = bounds.insetBy(dx: self.inset, dy: self.inset)
+        if (!self.showOptionButton) {
+            return rect
+        } else {
+            rect.size = CGSize(width: rect.width - (showButtonWidth - inset),
+                               height: rect.height)
+            return rect
+        }
+    }
+
+    override public func textRect(forBounds bounds: CGRect) -> CGRect {
+        calcRect(forBounds: bounds)
+    }
+
+    override public func editingRect(forBounds bounds: CGRect) -> CGRect {
+        calcRect(forBounds: bounds)
+    }
+
+    override public func placeholderRect(forBounds bounds: CGRect) -> CGRect {
+        calcRect(forBounds: bounds)
+    }
+
+
     override public func rightViewRect(forBounds bounds: CGRect) -> CGRect {
         if (!self.showOptionButton) {
             return CGRect(x: self.frame.width - self.inset, y: 0,

--- a/Sources/UI/Base/Form/Component/FormTextField.swift
+++ b/Sources/UI/Base/Form/Component/FormTextField.swift
@@ -49,10 +49,6 @@ public final class FormTextField: UITextField, UITextFieldDelegate {
 
     public let textPublisher = CurrentValueSubject<String, Never>("")
 
-    override public func leftViewRect(forBounds bounds: CGRect) -> CGRect {
-        return CGRect(x: 0, y: 0, width: self.inset, height: self.textFieldHeight)
-    }
-
     private func calcRect(forBounds bounds: CGRect) -> CGRect {
         var rect = bounds.insetBy(dx: self.inset, dy: self.inset)
         if (!self.showOptionButton) {
@@ -112,8 +108,6 @@ public final class FormTextField: UITextField, UITextFieldDelegate {
 
     private let underArrowView: UnderArrowView = .init()
 
-    /// 左側余白を表現するためのスペーサー
-    private let leftSpacerView: UIView = .init()
     /// optionButtonをTextField.rightViewにサイズ指定して表示するためのコンテナ
     private let optionButtonContainerView: UIView = .init()
     private let optionButton: UIButton = .init(
@@ -192,14 +186,10 @@ public final class FormTextField: UITextField, UITextFieldDelegate {
 
         /*
          テキスト入力エリア左右の余白
-         leftView, rightViewを使用して余白を設ける
+         rightViewを使用して余白を設ける
          セキュアのときはボタン用のスペースを算出し下記funcで返す必要がある
-         `leftViewRect(forBounds bounds: CGRect) -> CGRect`
          `rightViewRect(forBounds bounds: CGRect) -> CGRect`
          */
-        self.leftView = self.leftSpacerView
-        self.leftSpacerView.backgroundColor = .clear
-        self.leftViewMode = .always
         self.rightViewMode = .always
 
         self.optionButtonContainerView.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/UI/Base/Form/Component/FormTextField.swift
+++ b/Sources/UI/Base/Form/Component/FormTextField.swift
@@ -40,8 +40,11 @@ public final class FormTextField: UITextField, UITextFieldDelegate {
     // TODO: should remove this doubleList specfic property
     private var doubleList = ("", "")
 
+    /// テキストフィールド内のinset
     private let inset: CGFloat = 16
-    private let showButtonWidth: CGFloat = 70
+    /// 表示ボタンの横幅
+    private let showButtonWidth: CGFloat = 90
+    /// 表示ボタンの高さ
     private let textFieldHeight: CGFloat = 50
 
     public let textPublisher = CurrentValueSubject<String, Never>("")

--- a/Sources/UI/Base/Form/Component/FormTextField.swift
+++ b/Sources/UI/Base/Form/Component/FormTextField.swift
@@ -43,7 +43,7 @@ public final class FormTextField: UITextField, UITextFieldDelegate {
     /// テキストフィールド内のinset
     private let inset: CGFloat = 16
     /// 表示ボタンの横幅
-    private let showButtonWidth: CGFloat = 90
+    private let optionButtonWidth: CGFloat = 90
 
     public let textPublisher = CurrentValueSubject<String, Never>("")
 
@@ -53,7 +53,7 @@ public final class FormTextField: UITextField, UITextFieldDelegate {
             return rect
         } else {
             rect.size = CGSize(
-                width: rect.width - (self.showButtonWidth - self.inset),
+                width: rect.width - (self.optionButtonWidth - self.inset),
                 height: rect.height
             )
             return rect
@@ -82,9 +82,9 @@ public final class FormTextField: UITextField, UITextFieldDelegate {
             )
         } else {
             return CGRect(
-                x: self.frame.width - self.showButtonWidth,
+                x: self.frame.width - self.optionButtonWidth,
                 y: 0,
-                width: self.showButtonWidth,
+                width: self.optionButtonWidth,
                 height: bounds.height
             )
         }

--- a/Sources/UI/Base/Form/Component/FormTextField.swift
+++ b/Sources/UI/Base/Form/Component/FormTextField.swift
@@ -44,42 +44,49 @@ public final class FormTextField: UITextField, UITextFieldDelegate {
     private let inset: CGFloat = 16
     /// 表示ボタンの横幅
     private let showButtonWidth: CGFloat = 90
-    /// 表示ボタンの高さ
-    private let textFieldHeight: CGFloat = 50
 
     public let textPublisher = CurrentValueSubject<String, Never>("")
 
     private func calcRect(forBounds bounds: CGRect) -> CGRect {
         var rect = bounds.insetBy(dx: self.inset, dy: self.inset)
-        if (!self.showOptionButton) {
+        if !self.showOptionButton {
             return rect
         } else {
-            rect.size = CGSize(width: rect.width - (showButtonWidth - inset),
-                               height: rect.height)
+            rect.size = CGSize(
+                width: rect.width - (self.showButtonWidth - self.inset),
+                height: rect.height
+            )
             return rect
         }
     }
 
     override public func textRect(forBounds bounds: CGRect) -> CGRect {
-        calcRect(forBounds: bounds)
+        self.calcRect(forBounds: bounds)
     }
 
     override public func editingRect(forBounds bounds: CGRect) -> CGRect {
-        calcRect(forBounds: bounds)
+        self.calcRect(forBounds: bounds)
     }
 
     override public func placeholderRect(forBounds bounds: CGRect) -> CGRect {
-        calcRect(forBounds: bounds)
+        self.calcRect(forBounds: bounds)
     }
 
-
     override public func rightViewRect(forBounds bounds: CGRect) -> CGRect {
-        if (!self.showOptionButton) {
-            return CGRect(x: self.frame.width - self.inset, y: 0,
-                          width: self.inset, height: self.textFieldHeight)
+        if !self.showOptionButton {
+            return CGRect(
+                x: self.frame.width - self.inset,
+                y: 0,
+                width: self.inset,
+                height: bounds.height
+            )
         } else {
-            return CGRect(x: self.frame.width - self.showButtonWidth, y: 0,
-                          width: self.showButtonWidth, height: self.textFieldHeight)
+            return CGRect(
+                x: self.frame.width - self.showButtonWidth,
+                y: 0,
+                width: self.showButtonWidth,
+                height: bounds.height
+            )
         }
     }
 
@@ -116,7 +123,7 @@ public final class FormTextField: UITextField, UITextFieldDelegate {
         for: .normal
     )
 
-    private var showOptionButton: Bool = false
+    private let showOptionButton: Bool
     private var picker: Picker
 
     public init(
@@ -131,11 +138,11 @@ public final class FormTextField: UITextField, UITextFieldDelegate {
         dummyText: String = ""
     ) {
         self.picker = picker
+        self.showOptionButton = showOptionButton
 
         super.init(frame: .zero)
-        
+
         self.text = dummyText
-        self.showOptionButton = showOptionButton
         self.isSecureTextEntry = isSecureTextEntry
         self.delegate = self
         if let placeholderColor = placeholderColor {
@@ -184,39 +191,11 @@ public final class FormTextField: UITextField, UITextFieldDelegate {
             addArrowButton()
         }
 
-        /*
-         テキスト入力エリア左右の余白
-         rightViewを使用して余白を設ける
-         セキュアのときはボタン用のスペースを算出し下記funcで返す必要がある
-         `rightViewRect(forBounds bounds: CGRect) -> CGRect`
-         */
         self.rightViewMode = .always
-
-        self.optionButtonContainerView.translatesAutoresizingMaskIntoConstraints = false
-        self.optionButtonContainerView.backgroundColor = .clear
-        self.rightView = self.optionButtonContainerView
-        if (!self.showOptionButton) {
-            // 非セキュア
-            optionButtonContainerView.widthAnchor.constraint(equalToConstant: self.inset).isActive = true
-            optionButtonContainerView.heightAnchor.constraint(equalToConstant: self.textFieldHeight).isActive = true
-        } else {
-            // セキュア
-            // UITextField.rightViewに直接UIButtonをaddSubviewするとリサイズされてしまうためUIViewでwrapする
-            self.optionButton.translatesAutoresizingMaskIntoConstraints = false
-            self.optionButtonContainerView.addSubviews(
-                self.optionButton,
-                constraints:
-                self.optionButton.topAnchor.constraint(equalTo: self.optionButtonContainerView.topAnchor, constant: 0),
-                self.optionButton.leadingAnchor.constraint(equalTo: self.optionButtonContainerView.leadingAnchor, constant: 0),
-                self.optionButton.trailingAnchor.constraint(equalTo: self.optionButtonContainerView.trailingAnchor, constant: 0),
-                self.optionButton.bottomAnchor.constraint(equalTo: self.optionButtonContainerView.bottomAnchor, constant: 0),
-                self.optionButton.widthAnchor.constraint(equalToConstant: self.showButtonWidth),
-                self.optionButton.heightAnchor.constraint(equalToConstant: self.textFieldHeight)
-            )
-            optionButton.titleLabel?.textAlignment = .center
-            self.addTarget(self, action: #selector(self.didValueChanged), for: .editingChanged)
-            self.optionButton.addTarget(self, action: #selector(self.secureToggle), for: .touchUpInside)
-        }
+        self.rightView = self.optionButton
+        self.addTarget(self, action: #selector(self.didValueChanged), for: .editingChanged)
+        self.optionButton.addTarget(self, action: #selector(self.secureToggle), for: .touchUpInside)
+        self.optionButton.isHidden = !self.showOptionButton
     }
 
     @available(*, unavailable)


### PR DESCRIPTION
## Ticket

* https://e-medicaljapan.atlassian.net/browse/MZNE-1043

## Done

* パスワード入力欄の「表示」ボタンを、入力カーソルがパスワードフィールドにある状態でも押せるようにする

## Behaviour

* 動作確認手順
1. Playgroundで実行しセキュアなテキストフィールドで文字の入力
2. 「表示」ボタンをタップし表示/非表示がトグルすることを確認する
3. 別のテキストフィールドを選択し、元のテキストフィールドを非活性状態にしてから「表示」ボタンをタップし表示/非表示がトグルすることを確認する
4. 入力文字数が多いとき「表示」ボタンと文字が重ならないことを確認する

