### PR TITLE
CollectionViewのエンプティ表示対応

### DIFF
--- a/Sources/UI/Base/Collection/Collection.swift
+++ b/Sources/UI/Base/Collection/Collection.swift
@@ -13,6 +13,12 @@ public protocol CollectionList: List {
 
     var screenTitle: String { get }
     var hideTabbar: Bool { get }
+    /// 表示する要素が0件のときCollectionView.backgroundViewに設定されるView
+    ///
+    /// UICollectionViewの仕様でAutoLayoutがきかない
+    /// subviewをする場合はあらかじめframeを確定してビューを生成するか
+    /// UIView.AutoresizingMaskを指定する等が必要
+    var emptyBackgroundView: UIView? { get }
     var composableLayout: UICollectionViewCompositionalLayout { get }
     var topViewSubject: PassthroughSubject<Parameter, Never> { get }
     var fetchPublisher: ((parameter: Parameter?, isAdditional: Bool))

--- a/Sources/UI/Base/Collection/CollectionViewController.swift
+++ b/Sources/UI/Base/Collection/CollectionViewController.swift
@@ -48,6 +48,9 @@ public final class CollectionViewController<T: CollectionList>: UIViewController
         view.backgroundColor = self.collection.backgroundColor
 
         self.ui.setupView(rootview: view)
+        if let emptyBackgroundView = self.collection.emptyBackgroundView {
+            self.ui.setupEmptyBackgroundView(emptyBackgroundView)
+        }
 
         self.setupEvent()
 


### PR DESCRIPTION
CollectionViewのエンプティ表示対応をしました。
既存のemptyViewはデータ取得前に表示されますが、データ取得後は0件であってもemptyViewが表示されない問題がありました。
そのためデータ件数が0件のときに限りUICollectionView.backgroundViewに表示するためのビューをCollectionUIに追加しました。
