### PR TITLE
FormTextFieldの修正

### DIFF
--- a/Sources/UI/Base/Form/Component/FormTextField.swift
+++ b/Sources/UI/Base/Form/Component/FormTextField.swift
@@ -251,10 +251,11 @@ public final class FormTextField: UITextField, UITextFieldDelegate {
                 return text
             }()
 
-            self.text = string
+            if text != string {
+                self.text = string
+            }
 
-        default:
-            self.text = text
+        default: break
         }
     }
 


### PR DESCRIPTION
https://github.com/Caraquri/JINS-iOS-v2/issues/614
の対応

# 原因
`didValueChanged`で
self.textに値を設定している
値入力するたびにself.textの値が更新されているため常に入力完了状態になっていた
(ios15は入力完了状態にならないのはそれはそれでおかしい気をしますが…。)

# 対応
self.textに値を設定するは文字を編集処理が入った(上限超過やスペース入っている)時のみにする

## Video

ios14にて
上限値こえた場合はself.textに値を設定しているので入力完了状態になります。(これは問題ないと思ってますけど大丈夫ですよね)

<video src="https://user-images.githubusercontent.com/88297399/190069989-e074a9ae-76d3-407f-9097-3601090dc219.mp4" width="300"> |



#その他
多分問題ないと思いますが、今回の対応で他に影響があるか一応そちらでも確認お願いします
